### PR TITLE
add immutable config items by annotation

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -210,6 +210,16 @@ func generateSentinelConfigMap(rf *redisfailoverv1.RedisFailover, labels map[str
 
 func generateRedisConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference, password string) *corev1.ConfigMap {
 	name := GetRedisName(rf)
+
+	var addConfigLines []string
+	if rf.Annotations != nil {
+		for key, value := range rf.Annotations {
+			if strings.HasPrefix(key, "add-configuration-snippet") {
+				addConfigLines = append(addConfigLines, value)
+			}
+		}
+	}
+
 	labels = util.MergeLabels(labels, generateSelectorLabels(redisRoleName, rf.Name))
 
 	tmpl, err := template.New("redis").Parse(redisConfigTemplate)
@@ -223,6 +233,10 @@ func generateRedisConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string
 	}
 
 	redisConfigFileContent := tplOutput.String()
+
+	if len(addConfigLines) > 0 {
+		redisConfigFileContent = fmt.Sprintf("%s\n%s", redisConfigFileContent, strings.Join(addConfigLines, "\n"))
+	}
 
 	if password != "" {
 		redisConfigFileContent = fmt.Sprintf("%s\nmasterauth %s\nrequirepass %s", redisConfigFileContent, password, password)


### PR DESCRIPTION
allows to add immutable configuration settings to redis.conf template as annotation
```
metadata:
    annotations:
        add-configuration-snippet: |
          server_cpulist 0,2,4
          bio_cpulist 1
          aof_rewrite_cpulist 3
          bgsave_cpulist 3
          io-threads 2
          io-threads-do-reads no
```